### PR TITLE
Allow Multiple builds for one Hash Commit

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -86,7 +86,7 @@ curl $BITBUCKET_API_ENDPOINT \
   --data-binary \
       $"{
         \"state\": \"$BITBUCKET_BUILD_STATE\",
-        \"key\": \"Bitrise\",
+        \"key\": \"Bitrise - Build #$build_number \",
         \"name\": \"Bitrise $app_title #$build_number\",
         \"url\": \"$build_url\",
         \"description\": \"workflow: $triggered_workflow_id\"


### PR DESCRIPTION
Key for per build status should be unique, 
https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/#multiple-builds

Currently if you build a branch and PR for that branch both post build status to same commit with Key "Bitrise", so they override each other.
Also on Build tab on Bitbucket (or using get API) it displays only one build status.
