### PR TITLE
FIX use a more consistent 'key' value when updating Build Status

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -97,7 +97,7 @@ curl $BITBUCKET_API_ENDPOINT \
   --data-binary \
       $"{
         \"state\": \"$BITBUCKET_BUILD_STATE\",
-        \"key\": \"Bitrise - Build #$triggered_workflow_id\",
+        \"key\": \"Bitrise - Build $triggered_workflow_id\",
         \"name\": \"Bitrise $app_title ($triggered_workflow_id) #$build_number\",
         \"url\": \"$build_url\",
         \"description\": \"workflow: $triggered_workflow_id\"

--- a/step.sh
+++ b/step.sh
@@ -78,6 +78,17 @@ BITBUCKET_API_ENDPOINT="https://$domain/rest/build-status/1.0/commits/$git_clone
 echo "Post build status: $BITBUCKET_BUILD_STATE"
 echo "API Endpoint: $BITBUCKET_API_ENDPOINT"
 
+# Bitbucket is storing a build status per COMMIT_HASH && KEY.
+#
+# So updating the build status of an existing build from INPROGRESS
+# to FAILED or SUCCESSFUL needs to have the SAME commit_hash AND key!
+#
+# Also if the a developer simply re-runs a failed build on the same commit,
+# we also have to use the same key. Would otherwise result in having 2 separate
+# build status stored by Bitbucket for the same commit --> don't use $build_number for the KEY
+#
+# Docu: https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/
+
 curl $BITBUCKET_API_ENDPOINT \
   -X POST \
   -i \
@@ -86,8 +97,8 @@ curl $BITBUCKET_API_ENDPOINT \
   --data-binary \
       $"{
         \"state\": \"$BITBUCKET_BUILD_STATE\",
-        \"key\": \"Bitrise - Build #$build_number \",
-        \"name\": \"Bitrise $app_title #$build_number\",
+        \"key\": \"Bitrise - Build #$triggered_workflow_id\",
+        \"name\": \"Bitrise $app_title ($triggered_workflow_id) #$build_number\",
         \"url\": \"$build_url\",
         \"description\": \"workflow: $triggered_workflow_id\"
        }" \


### PR DESCRIPTION
We recently encountered a bug that resulted us not able to merge our PR in Bitbucket.

Our developer simply re-run the last build with same commit hash after receiving a failed build ❌ . This step created a 2nd build status (see screenshot with 2x `LATEST` tag).

![Screenshot 2022-03-18 at 16 59 09](https://user-images.githubusercontent.com/266349/159038444-80a67e21-ae04-4185-9f8c-f425613d64b1.png)

Bitbucket Server then disallowed the merge button, because there was another failed build for the same commit.

![Screenshot 2022-03-18 at 16 58 43](https://user-images.githubusercontent.com/266349/159038424-86edfaa6-247a-4a16-a4b2-baa8c7cc8209.png)

According to the [Bitbucket docu](https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/), it is storing a build result for each `key` **and** `commit_hash` pair.

![Screenshot 2022-03-18 at 17 03 46](https://user-images.githubusercontent.com/266349/159039128-00df5441-9912-4341-8dc7-d64bdee0b0bc.png)

But the current version was always using the `$build_number` as the `key` value. Which means that using "Rebuild" button in Bitrise will always result in adding a new build result entry in Bitbucket --> PRs can't be merged.

My fix is to simply use a more constant value `$triggered_workflow_id` for the `key` value.