### PR TITLE
Key made up of `BITRISE_BUILD_SLUG` and `BITRISE_BUILD_NUMBER`

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -93,7 +93,7 @@ curl $BITBUCKET_API_ENDPOINT \
   --data-binary \
       $"{
         \"state\": \"$BITBUCKET_BUILD_STATE\",
-        \"key\": \"Bitrise - Build $triggered_workflow_id\",
+        \"key\": \"Bitrise - $BITRISE_BUILD_SLUG - Build $triggered_workflow_id - #$BITRISE_BUILD_NUMBER\",
         \"name\": \"Bitrise $app_title ($triggered_workflow_id) #$build_number\",
         \"url\": \"$build_url\",
         \"description\": \"workflow: $triggered_workflow_id\"


### PR DESCRIPTION
We share one Bitbucket repository between two different Bitrise apps.

Build statuses reported to Bitbucket only include one of the builds triggered.

>This pull request addresses an issue where build statuses from different apps were overwriting each other in Bitbucket due to non-unique key values derived solely from workflow names. I have updated the script to generate unique key identifiers by incorporating the Bitrise app slug and build number. This change ensures independent status reporting for each app, enhancing clarity and traceability in our CI/CD pipeline.